### PR TITLE
Lower direct payment amount

### DIFF
--- a/scripts/request-vrf-direct.ts
+++ b/scripts/request-vrf-direct.ts
@@ -9,7 +9,7 @@ async function main() {
 
   const txReceipt = await (
     await vrfConsumer.requestRandomWordsDirect(keyHash, callbackGasLimit, numWords, {
-      value: ethers.utils.parseEther('3.0')
+      value: ethers.utils.parseEther('1.0')
     })
   ).wait()
 


### PR DESCRIPTION
Put back the default 1 $KLAY when requesting for randomness through temporary account.